### PR TITLE
Port Ishii PR 96: don't allow empty replay directory path

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceSlippi.cpp
@@ -497,6 +497,12 @@ void CEXISlippi::createNewFile()
   }
 
   std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
+  // in case the config value just gets lost somehow
+  if (dirpath.empty())
+  {
+    SConfig::GetInstance().m_strSlippiReplayDir = File::GetHomeDirectory() + DIR_SEP + "Slippi";
+    dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
+  }
 
   // Remove a trailing / or \\ if the user managed to have that in their config
   char dirpathEnd = dirpath.back();


### PR DESCRIPTION
Port commits from: project-slippi/Ishiiruka#96 for issue #6

This PR had 2 commits. I skipped one of the two: https://github.com/project-slippi/Ishiiruka/pull/96/commits/e31b2f1951f52653e7d74789f8278caf3d860c5e

That commit was redundant because I added the Slippi ini section and used the latest Ishii code when I did it.