### PR TITLE
Make uninitialized XFB gray on non-x86 systems too

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2428,16 +2428,7 @@ void TextureCacheBase::UninitializeXFBMemory(u8* dst, u32 stride, u32 bytes_per_
     }
 #endif
     for (u32 offset = 0; offset < size; offset++)
-    {
-      if (offset & 1)
-      {
-        rowdst[offset] = 254;
-      }
-      else
-      {
-        rowdst[offset] = 1;
-      }
-    }
+      rowdst[offset] = 0x80;
     dst += stride;
   }
 }


### PR DESCRIPTION
Not sure why it was changed to gray, but if it's gray on x86 it should be gray elsewhere too.