### PR TITLE
Apply -fno-objc-exceptions flag for ObjC sources only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   # Objective-C++ because fmt tries try to use throw because __EXCEPTIONS is defined.
   add_compile_options("$<$<COMPILE_LANGUAGE:OBJC>:-fno-objc-exceptions>")
   add_compile_options("$<$<COMPILE_LANGUAGE:OBJCXX>:-fno-objc-exceptions>")
+  dolphin_compile_definitions(FMT_EXCEPTIONS=0)
 
   find_library(APPKIT_LIBRARY AppKit)
   find_library(APPSERV_LIBRARY ApplicationServices)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,10 +305,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   # Set -fno-objc-exceptions, for consistency with -fno-exceptions earlier.
   # If we set only -fno-exceptions, fmt fails to compile when included from
   # Objective-C++ because fmt tries try to use throw because __EXCEPTIONS is defined.
-  #
-  # TODO: Only enable this for Objective-C(++).
-  # We get warnings if we enable this when building regular C(++) code.
-  check_and_add_flag(NO_OBJC_EXCEPTIONS -fno-objc-exceptions)
+  add_compile_options("$<$<COMPILE_LANGUAGE:OBJC>:-fno-objc-exceptions>")
+  add_compile_options("$<$<COMPILE_LANGUAGE:OBJCXX>:-fno-objc-exceptions>")
 
   find_library(APPKIT_LIBRARY AppKit)
   find_library(APPSERV_LIBRARY ApplicationServices)


### PR DESCRIPTION
This flag works on GCC and Clang which afaik are the only supported
compilers on Darwin, but cases can be added for more compilers if needed.
This is done instead of a more generic cmake compiler flag check
because CheckOBJC[XX]CompilerFlag requires CMake v3.16.