### PR TITLE
make mac ci great again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -400,7 +400,6 @@ jobs:
           cd ./build/Binaries/
           cp -Rf ../../Data/Sys ./Dolphin.app/Contents/Resources
           cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/Sys ./Dolphin.app/Contents/Resources
-          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/User ./Dolphin.app/Contents/Resources
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-macOS-playback.zip
           zip -r "${FILE_NAME}" Dolphin.app
           mv "${FILE_NAME}" ../../artifact/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -330,7 +330,6 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-macOS-netplay.tar.gz
-          echo "::set-env name=FILE_NAME::${FILE_NAME}"
           cp -Rf Data/Sys build/Binaries/Dolphin.app/Contents/Resources/
           mkdir artifact
           cd ./build/Binaries/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,6 +302,7 @@ jobs:
         if: success()
         shell: bash
         run: |
+          rm '/usr/local/bin/2to3' || true
           brew update
           brew upgrade cmake
           brew install \
@@ -368,6 +369,7 @@ jobs:
         if: success()
         shell: bash
         run: |
+          rm '/usr/local/bin/2to3' || true
           brew update
           brew upgrade cmake
           brew install \


### PR DESCRIPTION
@r2dliu 
@NikhilNarayana 
original error in brew install
![image](https://user-images.githubusercontent.com/481161/104113661-12e56280-533f-11eb-9eff-d6cb994b9b3a.png)

removing set-env echo because it caused error due to it being deprecated:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

app/dolphin-dev/overwrite/User was removed from slippi-desktop-app repo, so we shouldn't try copying it:
https://github.com/project-slippi/slippi-desktop-app/commit/c7c4ecb7088709185a7a8a41326695fd2ff0068a

