### PR TITLE
faster build

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -32,7 +32,7 @@ fi
 mkdir -p build
 pushd build
 cmake ${CMAKE_FLAGS} ..
-make -j7
+make -j$(nproc)
 popd
 
 # Copy the Sys folder in


### PR DESCRIPTION
Minor edit that brings the Mac builder in line with `build-linux.sh` by compiling with as many threads as the hardware has available.